### PR TITLE
Remove hard coded owner from tests

### DIFF
--- a/git/git_test.go
+++ b/git/git_test.go
@@ -32,7 +32,7 @@ func TestGitEditorPath(t *testing.T) {
 
 func TestGitRemote(t *testing.T) {
 	gitRemote, _ := Remote()
-	assert.T(t, strings.Contains(gitRemote, "jingweno/gh.git"))
+	assert.T(t, strings.Contains(gitRemote, "/gh.git"))
 }
 
 func TestGitHead(t *testing.T) {

--- a/github/project_test.go
+++ b/github/project_test.go
@@ -17,7 +17,9 @@ func TestWebURL(t *testing.T) {
 func TestParseNameAndOwner(t *testing.T) {
 	owner, name := parseOwnerAndName()
 	assert.Equal(t, "gh", name)
-	assert.Equal(t, "jingweno", owner)
+
+	ownerNotEmpty := len(owner) != 0
+	assert.Equal(t, ownerNotEmpty, true)
 }
 
 func TestMustMatchGitHubURL(t *testing.T) {


### PR DESCRIPTION
Was wanting to hack on the project and hit a stumbling block when
running the tests because of the hard coded repo owner. I made some
guesses about the project_test resolution, so feel free to let me know if you'd
like it done another way.
