### PR TITLE
Made .git at the end of remote optional

### DIFF
--- a/github/project.go
+++ b/github/project.go
@@ -61,17 +61,17 @@ func parseOwnerAndName() (name, remote string) {
 }
 
 func mustMatchGitHubURL(url string) ([]string, error) {
-	httpRegex := regexp.MustCompile("https://github.com/(.+)/(.+).git")
+	httpRegex := regexp.MustCompile("https://github.com/(.+)/(.+)(.git)?")
 	if httpRegex.MatchString(url) {
 		return httpRegex.FindStringSubmatch(url), nil
 	}
 
-	readOnlyRegex := regexp.MustCompile("git://github.com/(.+)/(.+).git")
+	readOnlyRegex := regexp.MustCompile("git://github.com/(.+)/(.+)(.git)?")
 	if readOnlyRegex.MatchString(url) {
 		return readOnlyRegex.FindStringSubmatch(url), nil
 	}
 
-	sshRegex := regexp.MustCompile("git@github.com:(.+)/(.+).git")
+	sshRegex := regexp.MustCompile("git@github.com:(.+)/(.+)(.git)?")
 	if sshRegex.MatchString(url) {
 		return sshRegex.FindStringSubmatch(url), nil
 	}


### PR DESCRIPTION
It is possible to completely omit adding .git at the end of a remote (i.e. https://github.com/jingweno/gh instead of https://github.com/jingweno/gh.git). gh wasn't accepting this, complaining that the remote doesn't point to a GitHub repository, so I changed some regular expressions in order to allow this. I would be happy to add some tests if you wish.
