### PR TITLE
Tests now don't rely on particular owner username to pass

### DIFF
--- a/git/git_test.go
+++ b/git/git_test.go
@@ -32,7 +32,7 @@ func TestGitEditorPath(t *testing.T) {
 
 func TestGitRemote(t *testing.T) {
 	gitRemote, _ := Remote()
-	assert.T(t, strings.Contains(gitRemote, "jingweno/gh.git"))
+	assert.T(t, strings.Contains(gitRemote, "gh.git"))
 }
 
 func TestGitHead(t *testing.T) {

--- a/github/project.go
+++ b/github/project.go
@@ -45,15 +45,15 @@ func (p *Project) LocalRepo() *Repo {
 }
 
 func CurrentProject() *Project {
-	owner, name := parseOwnerAndName()
+	remote, err := git.Remote()
+	utils.Check(err)
+
+	owner, name := parseOwnerAndName(remote)
 
 	return &Project{name, owner}
 }
 
-func parseOwnerAndName() (name, remote string) {
-	remote, err := git.Remote()
-	utils.Check(err)
-
+func parseOwnerAndName(remote string) (owner string, name string) {
 	url, err := mustMatchGitHubURL(remote)
 	utils.Check(err)
 

--- a/github/project_test.go
+++ b/github/project_test.go
@@ -14,8 +14,8 @@ func TestWebURL(t *testing.T) {
 	assert.Equal(t, "https://github.com/2/1", url)
 }
 
-func TestParseNameAndOwner(t *testing.T) {
-	owner, name := parseOwnerAndName()
+func TestParseOwnerAndName(t *testing.T) {
+	owner, name := parseOwnerAndName("git://github.com/jingweno/gh.git")
 	assert.Equal(t, "gh", name)
 	assert.Equal(t, "jingweno", owner)
 }


### PR DESCRIPTION
Also tiny refactor of project.go to be more testable.
