### PR TITLE
Escaped regexp dots

### DIFF
--- a/github/project.go
+++ b/github/project.go
@@ -61,17 +61,17 @@ func parseOwnerAndName(remote string) (owner string, name string) {
 }
 
 func mustMatchGitHubURL(url string) ([]string, error) {
-	httpRegex := regexp.MustCompile("https://github.com/(.+)/(.+?)(.git|$)")
+	httpRegex := regexp.MustCompile("https://github\.com/(.+)/(.+)(\.git|$)")
 	if httpRegex.MatchString(url) {
 		return httpRegex.FindStringSubmatch(url), nil
 	}
 
-	readOnlyRegex := regexp.MustCompile("git://github.com/(.+)/(.+?)(.git|$)")
+	readOnlyRegex := regexp.MustCompile("git://github\.com/(.+)/(.+)(\.git|$)")
 	if readOnlyRegex.MatchString(url) {
 		return readOnlyRegex.FindStringSubmatch(url), nil
 	}
 
-	sshRegex := regexp.MustCompile("git@github.com:(.+)/(.+?)(.git|$)")
+	sshRegex := regexp.MustCompile("git@github\.com:(.+)/(.+)(\.git|$)")
 	if sshRegex.MatchString(url) {
 		return sshRegex.FindStringSubmatch(url), nil
 	}


### PR DESCRIPTION
In regexp, . (dot) means "any character", while . (backslash-dot) means "dot". I corrected your regexps to use github.com instead of github.com (which allows githubycom for example) and .git instead of .git. I guess you already know that, I'm just pointing it out.
