### PR TITLE
Wrong command in README (browse section)

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,10 +155,10 @@ To upgrade gh from source, run:
     $ gh browse -u jingweno -r gh commit/SHA
     > open https://github.com/jingweno/gh/commit/SHA
 
-    $ git browse -r resque
+    $ gh browse -r resque
     > open https://github.com/YOUR_USER/resque
 
-    $ git browse -r resque network
+    $ gh browse -r resque network
     > open https://github.com/YOUR_USER/resque/network
 
 ### gh compare


### PR DESCRIPTION
just have a look at https://github.com/jingweno/gh#gh-browse

the last two commands mentioned start with `git` not `gh` is this correct, or just a typo?

```
$ git browse -r resque
> open https://github.com/YOUR_USER/resque

$ git browse -r resque network
> open https://github.com/YOUR_USER/resque/network
```
