### PR TITLE
gh browse always opens master

### DIFF
--- a/git/branch.go
+++ b/git/branch.go
@@ -1,0 +1,14 @@
+package git
+
+import (
+	"regexp"
+)
+
+type Branch struct {
+	Name string
+}
+
+func (b *Branch) ShortName() string {
+	reg := regexp.MustCompile("^refs/(remotes/)?.+?/")
+	return reg.ReplaceAllString(b.Name, "")
+}

--- a/git/branch_test.go
+++ b/git/branch_test.go
@@ -1,0 +1,11 @@
+package git
+
+import (
+	"github.com/bmizerany/assert"
+	"testing"
+)
+
+func TestShortName(t *testing.T) {
+	b := Branch{"refs/heads/master"}
+	assert.Equal(t, "master", b.ShortName())
+}

--- a/git/git.go
+++ b/git/git.go
@@ -73,13 +73,13 @@ func EditorPath() (string, error) {
 	return editorPath, nil
 }
 
-func Head() (string, error) {
-	output, err := execGitCmd("symbolic-ref", "-q", "--short", "HEAD")
+func Head() (*Branch, error) {
+	output, err := execGitCmd("symbolic-ref", "-q", "HEAD")
 	if err != nil {
-		return "master", errors.New("Can't load git HEAD")
+		return nil, errors.New("Can't load git HEAD")
 	}
 
-	return output[0], nil
+	return &Branch{output[0]}, nil
 }
 
 func Ref(ref string) (string, error) {

--- a/github/project.go
+++ b/github/project.go
@@ -53,7 +53,9 @@ func (p *Project) LocalRepoWith(base, head string) *Repo {
 		base = "master"
 	}
 	if head == "" {
-		head, _ = git.Head()
+		headBranch, err := git.Head()
+		utils.Check(err)
+		head = headBranch.ShortName()
 	}
 
 	return &Repo{base, head, p}


### PR DESCRIPTION
When I type `gh browse`, it always shows me a view of the master branch instead of the branch I am working on. 

It would be more useful if in case my local branch in tracking a different branch remotely, that it shows that.
