### PR TITLE
fix issue with no args on push

### DIFF
--- a/commands/push.go
+++ b/commands/push.go
@@ -25,7 +25,7 @@ multiple git-push(1) commands.`,
   > git push origin HEAD
 */
 func push(command *Command, args *Args) {
-	if !args.IsParamsEmpty() || !strings.Contains(args.FirstParam(), ",") {
+	if !args.IsParamsEmpty() && !strings.Contains(args.FirstParam(), ",") {
 		transformPushArgs(args)
 	}
 }


### PR DESCRIPTION
With no arguments to `gh push`, a run-time error occured; out-of-bounds index for args.FirstParam(). 

I assume it was a mistake to use `||` rather than `&&`. 
