### PR TITLE
gh pull-request won't start with flags in core.editor

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/jingweno/gh/utils"
+	"github.com/kballard/go-shellquote"
 	"os"
 	"os/exec"
 	"strings"
@@ -52,8 +54,16 @@ func (cmd *Cmd) Exec() error {
 	return c.Run()
 }
 
-func New(name string) *Cmd {
-	return &Cmd{Name: name, Args: make([]string, 0)}
+func New(cmd string) *Cmd {
+	cmds, err := shellquote.Split(cmd)
+	utils.Check(err)
+
+	name := cmds[0]
+	args := make([]string, 0)
+	for _, arg := range cmds[1:] {
+		args = append(args, arg)
+	}
+	return &Cmd{Name: name, Args: args}
 }
 
 func NewWithArray(cmd []string) *Cmd {

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -5,6 +5,13 @@ import (
 	"testing"
 )
 
+func TestNew(t *testing.T) {
+	execCmd := New("vim --noplugin")
+	assert.Equal(t, "vim", execCmd.Name)
+	assert.Equal(t, 1, len(execCmd.Args))
+	assert.Equal(t, "--noplugin", execCmd.Args[0])
+}
+
 func TestWithArg(t *testing.T) {
 	execCmd := New("git")
 	execCmd.WithArg("log").WithArg("--no-color")

--- a/commands/pull_request.go
+++ b/commands/pull_request.go
@@ -105,12 +105,12 @@ func writePullRequestTitleAndBody(repo *github.Repo) (title, body string, err er
 		return
 	}
 
-	editorPath, err := git.EditorPath()
+	editor, err := git.Editor()
 	if err != nil {
 		return
 	}
 
-	err = editTitleAndBody(editorPath, messageFile)
+	err = editTitleAndBody(editor, messageFile)
 	if err != nil {
 		return
 	}
@@ -154,10 +154,10 @@ func writePullRequestChanges(repo *github.Repo, messageFile string) error {
 	return ioutil.WriteFile(messageFile, []byte(message), 0644)
 }
 
-func editTitleAndBody(editorPath, messageFile string) error {
-	editCmd := cmd.New(editorPath)
+func editTitleAndBody(editor, messageFile string) error {
+	editCmd := cmd.New(editor)
 	r := regexp.MustCompile("[mg]?vi[m]$")
-	if r.MatchString(editorPath) {
+	if r.MatchString(editor) {
 		editCmd.WithArg("-c")
 		editCmd.WithArg("set ft=gitcommit tw=0 wrap lbr")
 	}

--- a/git/git.go
+++ b/git/git.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"github.com/jingweno/gh/cmd"
-	"os/exec"
 	"path/filepath"
 	"strings"
 )
@@ -49,28 +48,6 @@ func Editor() (string, error) {
 	}
 
 	return output[0], nil
-}
-
-func EditorPath() (string, error) {
-	gitEditor, err := Editor()
-	if err != nil {
-		return "", err
-	}
-
-	gitEditorWithParams := strings.Split(gitEditor, " ")
-	gitEditor = gitEditorWithParams[0]
-	gitEditorParams := gitEditorWithParams[1:]
-
-	editorPath, err := exec.LookPath(gitEditor)
-	if err != nil {
-		return "", errors.New("Can't locate git editor: " + gitEditor)
-	}
-
-	for _, p := range gitEditorParams {
-		editorPath = editorPath + " " + p
-	}
-
-	return editorPath, nil
 }
 
 func Head() (*Branch, error) {

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -23,13 +23,6 @@ func TestGitEditor(t *testing.T) {
 	}
 }
 
-func TestGitEditorPath(t *testing.T) {
-	gitEditorPath, err := EditorPath()
-	if err == nil {
-		assert.NotEqual(t, "", gitEditorPath)
-	}
-}
-
 func TestGitRemote(t *testing.T) {
 	gitRemote, _ := OriginRemote()
 	assert.Equal(t, "origin", gitRemote.Name)


### PR DESCRIPTION
For example,

```
[core]
  editor = vim --noplugin
```

This gives me:
    2013/11/26 13:32:04 fatal: command not found: /usr/bin/vim --noplugin

While this works fine

```
[core]
  editor = vim
```

Meanwhile, [hub](hub.github.com) works with both cases.
