### PR TITLE
gh pull-request always tells me I have unpushed commits

### DIFF
--- a/commands/pull_request.go
+++ b/commands/pull_request.go
@@ -168,14 +168,17 @@ func pullRequest(cmd *Command, args *Args) {
 	fullBase := fmt.Sprintf("%s:%s", baseProject.Owner, base)
 	fullHead := fmt.Sprintf("%s:%s", headProject.Owner, head)
 
-	commits, _ := git.RefList(base, head)
-	if !force && trackedBranch != nil && len(commits) > 0 {
-		err = fmt.Errorf("Aborted: %d commits are not yet pushed to %s", len(commits), trackedBranch.LongName())
-		err = fmt.Errorf("%s\n(use `-f` to force submit a pull request anyway)", err)
-		utils.Check(err)
+	if !force && trackedBranch != nil {
+		remoteCommits, _ := git.RefList(trackedBranch.LongName(), "")
+		if len(remoteCommits) > 0 {
+			err = fmt.Errorf("Aborted: %d commits are not yet pushed to %s", len(remoteCommits), trackedBranch.LongName())
+			err = fmt.Errorf("%s\n(use `-f` to force submit a pull request anyway)", err)
+			utils.Check(err)
+		}
 	}
 
 	if title == "" && flagPullRequestIssue == "" {
+		commits, _ := git.RefList(base, head)
 		t, b, err := writePullRequestTitleAndBody(base, head, fullBase, fullHead, commits)
 		utils.Check(err)
 		title = t


### PR DESCRIPTION
This code in pull_request.go is wrong:

```
 commits, _ := git.RefList(base, head)
 if !force && trackedBranch != nil && len(commits) > 0 {
                err = fmt.Errorf("Aborted: %d commits are not yet pushed to %s", len(commits), trackedBranch.LongName())
                err = fmt.Errorf("%s\n(use `-f` to force submit a pull request anyway)", err)
                utils.Check(err)
        }

```

My work flow is:

```
gh fork
git checkout -b my-fixes-branch
git commit -am "fixes"
git push dgryski -u my-fixes-branch
gh pull-request
```

It generates this error:

```
2013/12/18 21:27:53 fatal: Aborted: 1 commits are not yet pushed to dgryski/otp-case-fixes
(use `-f` to force submit a pull request anyway)
```

So isn't it complaining about exactly the one commit I want to push?  If I try to push to my branch, git tells me I'm up-to-date.  fullBase in this case is pointing at origin/master, but I think it should be the my tracked branch.
