### PR TITLE
gh breaks ! aliases

### DIFF
--- a/commands/runner.go
+++ b/commands/runner.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jingweno/gh/utils"
 	"github.com/kballard/go-shellquote"
 	"os/exec"
+	"strings"
 	"syscall"
 )
 
@@ -117,10 +118,27 @@ func expandAlias(args *Args) {
 	cmd := args.Command
 	expandedCmd, err := git.Alias(cmd)
 	if err == nil && expandedCmd != "" {
-		words, err := shellquote.Split(expandedCmd)
-		if err == nil && len(words) > 0 {
+		words, e := splitAliasCmd(expandedCmd)
+		if e == nil {
 			args.Command = words[0]
 			args.PrependParams(words[1:]...)
 		}
 	}
+}
+
+func splitAliasCmd(cmd string) ([]string, error) {
+	if cmd == "" {
+		return nil, fmt.Errorf("alias can't be empty")
+	}
+
+	if strings.HasPrefix(cmd, "!") {
+		return nil, fmt.Errorf("alias starting with ! can't be split")
+	}
+
+	words, err := shellquote.Split(cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	return words, nil
 }

--- a/commands/runner_test.go
+++ b/commands/runner_test.go
@@ -1,0 +1,18 @@
+package commands
+
+import (
+	"github.com/bmizerany/assert"
+	"testing"
+)
+
+func TestRunner_splitAliasCmd(t *testing.T) {
+	words, err := splitAliasCmd("!source ~/.zshrc")
+	assert.NotEqual(t, nil, err)
+
+	words, err = splitAliasCmd("log --pretty=oneline --abbrev-commit --graph --decorate")
+	assert.Equal(t, nil, err)
+	assert.Equal(t, 5, len(words))
+
+	words, err = splitAliasCmd("")
+	assert.NotEqual(t, nil, err)
+}


### PR DESCRIPTION
A git alias which begins with `!` executes a shell command. A recent update to `gh` broke this functionality.

```
❯❯❯ gh config alias.l
!source ~/.githelpers && pretty_git_log

❯❯❯ gh l
git: '!source' is not a git command. See 'git --help'.
```
