### PR TITLE
Fix typo in git show format

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -117,12 +117,13 @@ func RefList(a, b string) ([]string, error) {
 }
 
 func Show(sha string) (string, error) {
-	output, err := execGitCmd("show", "-s", "--format=%w(78,0,0)%s%+b", sha)
-	if err != nil {
-		return "", fmt.Errorf("Can't show commit for %s", sha)
-	}
+	cmd := cmd.New("git")
+	cmd.WithArg("show").WithArg("-s").WithArg("--format=%w(78,0,0)%s%n%+b").WithArg(sha)
 
-	return output[0], nil
+	output, err := cmd.ExecOutput()
+	output = strings.TrimSpace(output)
+
+	return output, err
 }
 
 func Log(sha1, sha2 string) (string, error) {

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -39,7 +39,7 @@ func TestGitRefList(t *testing.T) {
 }
 
 func TestGitShow(t *testing.T) {
-	output, err := Show("ce20e63ad00751bfed5d08072b11cf1b43af1995")
+	output, err := Show("8494cd083d5e5817f4aa75fb8a3973ecfd39f2f8")
 	assert.Equal(t, nil, err)
-	assert.Equal(t, "Add Git.RefList", output)
+	assert.Equal(t, "Fix typo in git show format\n\nIt's possible that comments are multiple lines", output)
 }


### PR DESCRIPTION
It's possible that comments are multiple lines
