### PR TITLE
mktemp -t takes a prefix, not a template.

### DIFF
--- a/script/make
+++ b/script/make
@@ -7,7 +7,7 @@
 
 set -e
 
-BUILD_DIR=`mktemp -d -t gh.XXXXXX`
+BUILD_DIR=`mktemp -d -t gh`
 GODEPPATH=`pwd`/Godeps/_workspace
 GHSOURCE=$BUILD_DIR/src/github.com/jingweno/gh
 


### PR DESCRIPTION
With -t, mktemp will build the template for you from a prefix, making the
.XXXXXX unnecessary.
