### PR TITLE
Add contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+## Submitting a Pull Request
+
+1. [Fork the repository.][fork]
+2. [Create a topic branch.][branch]
+3. Add tests for your unimplemented feature or bug fix.
+4. Run `script/test`. If your tests pass, return to step 3.
+5. Implement your feature or bug fix.
+6. Run `script/test`. If your tests fail, return to step 5.
+7. Add, commit, and push your changes. For documentation-only fixes,
+   please add "[ci skip]" to your commit message to avoid needless CI builds.
+8. [Submit a pull request.][pr]
+
+[fork]: https://help.github.com/articles/fork-a-repo
+[branch]: http://learn.github.com/p/branching.html
+[pr]: https://help.github.com/articles/using-pull-requests

--- a/README.md
+++ b/README.md
@@ -457,6 +457,8 @@ For your convenience, there is a script to run the tests.
 $ ./script/test
 ```
 
+See [this guide](https://github.com/jingweno/gh/blob/master/CONTRIBUTING.md) on how to submit a pull request.
+
 Contributors
 ------------
 


### PR DESCRIPTION
Thanks https://github.com/pengwynn/flint!

Before:

```
$ ./flint
[WARNING] Contributing guide not found
[FIXME] Add a CONTRIBUTING guide for potential contributors. http://git.io/z-TiGg
[WARNING] Some warnings found.
```

After:

```
$ ./flint
[OK] All is well!
```

/cc @pengwynn
