### PR TITLE
Escape slashes in compare URLs with semicolon

### DIFF
--- a/commands/compare.go
+++ b/commands/compare.go
@@ -2,9 +2,11 @@ package commands
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
+
 	"github.com/jingweno/gh/github"
 	"github.com/jingweno/gh/utils"
-	"regexp"
 )
 
 var cmdCompare = &Command{
@@ -71,6 +73,7 @@ func compare(command *Command, args *Args) {
 		}
 	}
 
+	r = strings.Replace(r, "/", ";", -1)
 	subpage := utils.ConcatPaths("compare", r)
 	url := project.WebURL("", "", subpage)
 	launcher, err := utils.BrowserLauncher()

--- a/features/compare.feature
+++ b/features/compare.feature
@@ -8,6 +8,11 @@ Feature: hub compare
     Then there should be no output
     And "open https://github.com/mislav/dotfiles/compare/refactor" should be run
 
+   Scenario: Compare complex branch
+    When I successfully run `hub compare feature/foo`
+    Then there should be no output
+    And "open https://github.com/mislav/dotfiles/compare/feature;foo" should be run
+
   Scenario: No args, no upstream
     When I run `hub compare`
     Then the exit status should be 1


### PR DESCRIPTION
Pull in Hub compatible fixes in
https://github.com/github/hub/commit/f60fb89274d276034e5c7c2d65f27d36dcfac685
