### PR TITLE
Set `gh.host` after a successful clone.

### DIFF
--- a/commands/clone.go
+++ b/commands/clone.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"github.com/jingweno/gh/git"
 	"github.com/jingweno/gh/github"
 	"regexp"
 	"strings"
@@ -8,6 +9,7 @@ import (
 
 var cmdClone = &Command{
 	Run:          clone,
+	PostSpawn:    saveHost,
 	GitExtension: true,
 	Usage:        "clone [-p] OPTIONS [USER/]REPOSITORY DIRECTORY",
 	Short:        "Clone a remote repository into a new directory",
@@ -38,6 +40,18 @@ func init() {
 func clone(command *Command, args *Args) {
 	if !args.IsParamsEmpty() {
 		transformCloneArgs(args)
+	}
+}
+
+// Save the host from where we're cloned as `gh.host` in the git configuration.
+func saveHost(args *Args) {
+	for i := 0; i < args.ParamsSize(); i++ {
+		a := args.Params[i]
+		gitUrl, err := git.ParseURL(a)
+		if err == nil {
+			git.SetConfig(github.GhHostConfig, gitUrl.Host)
+			break
+		}
 	}
 }
 

--- a/commands/clone_test.go
+++ b/commands/clone_test.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"github.com/bmizerany/assert"
+	"github.com/jingweno/gh/git"
 	"github.com/jingweno/gh/github"
 	"os"
 	"testing"
@@ -53,4 +54,38 @@ func TestTransformCloneArgs(t *testing.T) {
 	assert.Equal(t, 2, args.ParamsSize())
 	assert.Equal(t, "git://github.com/jingweno/gh", args.FirstParam())
 	assert.Equal(t, "gh", args.GetParam(1))
+}
+
+func TestSaveHost(t *testing.T) {
+	defer git.UnsetConfig(github.GhHostConfig)
+
+	args := NewArgs([]string{"clone", "git://github.com/jingweno/gh"})
+	saveHost(args)
+	v, _ := git.Config(github.GhHostConfig)
+	assert.Equal(t, "github.com", v)
+	git.UnsetConfig(github.GhHostConfig)
+
+	args = NewArgs([]string{"clone", "http://github.com/jingweno/gh"})
+	saveHost(args)
+	v, _ = git.Config(github.GhHostConfig)
+	assert.Equal(t, "github.com", v)
+	git.UnsetConfig(github.GhHostConfig)
+
+	args = NewArgs([]string{"clone", "http://github.enterprise.com/jingweno/gh"})
+	saveHost(args)
+	v, _ = git.Config(github.GhHostConfig)
+	assert.Equal(t, "github.enterprise.com", v)
+	git.UnsetConfig(github.GhHostConfig)
+
+	args = NewArgs([]string{"clone", "https://github.enterprise.com/jingweno/gh"})
+	saveHost(args)
+	v, _ = git.Config(github.GhHostConfig)
+	assert.Equal(t, "github.enterprise.com", v)
+	git.UnsetConfig(github.GhHostConfig)
+
+	args = NewArgs([]string{"clone", "git@github.enterprise.com:jingweno/jekyll_and_hyde.git"})
+	saveHost(args)
+	v, _ = git.Config(github.GhHostConfig)
+	assert.Equal(t, "github.enterprise.com", v)
+	git.UnsetConfig(github.GhHostConfig)
 }

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -16,7 +16,9 @@ var (
 )
 
 type Command struct {
-	Run  func(cmd *Command, args *Args)
+	Run       func(cmd *Command, args *Args)
+	PostSpawn func(args *Args)
+
 	Flag flag.FlagSet
 
 	Key          string

--- a/commands/runner.go
+++ b/commands/runner.go
@@ -77,6 +77,10 @@ func (r *Runner) Execute() ExecError {
 	}
 
 	err = git.Spawn(args.Command, args.Params...)
+
+	if err == nil && cmd.PostSpawn != nil {
+		cmd.PostSpawn(args)
+	}
 	return newExecError(err)
 }
 

--- a/git/git.go
+++ b/git/git.go
@@ -150,6 +150,16 @@ func Config(name string) (string, error) {
 	return gitGetConfig(name)
 }
 
+func SetConfig(name, value string) error {
+	_, err := gitConfig(name, value)
+	return err
+}
+
+func UnsetConfig(name string) error {
+	_, err := gitConfig("--unset", name)
+	return err
+}
+
 func GlobalConfig(name string) (string, error) {
 	return gitGetConfig("--global", name)
 }

--- a/github/hosts.go
+++ b/github/hosts.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 )
 
+const GhHostConfig = "gh.host"
+
 var (
 	GitHubHostEnv = os.Getenv("GITHUB_HOST")
 )
@@ -24,7 +26,7 @@ func (h Hosts) Include(host string) bool {
 }
 
 func knownHosts() (hosts Hosts) {
-	ghHosts, _ := git.Config("gh.host")
+	ghHosts, _ := git.Config(GhHostConfig)
 	for _, ghHost := range strings.Split(ghHosts, "\n") {
 		hosts = append(hosts, ghHost)
 	}


### PR DESCRIPTION
We assume that if you're using gh to clone a repo this one is on GitHub or
GitHub Enterprise. This way, when you use command that requires the host for
the first time it's already set.
