### PR TITLE
removes the replacement of . for browse command

### DIFF
--- a/commands/browse.go
+++ b/commands/browse.go
@@ -109,7 +109,7 @@ func browse(command *Command, args *Args) {
 }
 
 func branchInURL(branch *github.Branch) string {
-	parts := strings.Split(strings.Replace(branch.ShortName(), ".", "/", -1), "/")
+	parts := strings.Split(branch.ShortName(), "/")
 	newPath := make([]string, len(parts))
 	for i, s := range parts {
 		newPath[i] = url.QueryEscape(s)

--- a/features/browse.feature
+++ b/features/browse.feature
@@ -83,12 +83,19 @@ Feature: hub browse
     When I successfully run `hub browse commits`
     Then "open https://github.com/mislav/dotfiles/commits/experimental" should be run
 
-  Scenario: Complex branch
+  Scenario: Forward Slash Delimited branch
     Given I am in "git://github.com/mislav/dotfiles.git" git repo
     And git "push.default" is set to "upstream"
     And I am on the "foo/bar" branch with upstream "origin/baz/qux/moo"
     When I successfully run `hub browse`
     Then "open https://github.com/mislav/dotfiles/tree/baz/qux/moo" should be run
+
+  Scenario: Dot Delimited branch
+    Given I am in "git://github.com/mislav/dotfiles.git" git repo
+    And git "push.default" is set to "upstream"
+    And I am on the "fix-glob-for.js" branch with upstream "origin/fix-glob-for.js"
+    When I successfully run `hub browse`
+    Then "open https://github.com/mislav/dotfiles/tree/fix-glob-for.js" should be run
 
   Scenario: Wiki repo
     Given I am in "git://github.com/defunkt/hub.wiki.git" git repo


### PR DESCRIPTION
As it stands now, this replacement breaks browse for branches like `fix-glob-for.js` where it changes the path of the URL to `fix-glob-for/js` which is incorrect.

This is my first `go` code contribution so I expect feedback and suggestions.

Also, though I added a supporting test, I was unable to validate it since I'm still figuring out how to set all of this up. Was hoping travis would give me a hint and I could go from there.
