### PR TITLE
Add -o option to pull-request

### DIFF
--- a/commands/pull_request.go
+++ b/commands/pull_request.go
@@ -39,7 +39,8 @@ var (
 	flagPullRequestIssue,
 	flagPullRequestMessage,
 	flagPullRequestFile string
-	flagPullRequestForce bool
+	flagPullRequestForce     bool
+	flagBrowsePullRequestURL bool
 )
 
 func init() {
@@ -49,6 +50,7 @@ func init() {
 	cmdPullRequest.Flag.StringVarP(&flagPullRequestMessage, "message", "m", "", "MESSAGE")
 	cmdPullRequest.Flag.BoolVarP(&flagPullRequestForce, "force", "f", false, "FORCE")
 	cmdPullRequest.Flag.StringVarP(&flagPullRequestFile, "file", "F", "", "FILE")
+	cmdPullRequest.Flag.BoolVarP(&flagBrowsePullRequestURL, "browse", "o", false, "BROWSE")
 
 	CmdRunner.Use(cmdPullRequest)
 }
@@ -176,7 +178,16 @@ func pullRequest(cmd *Command, args *Args) {
 		}
 	}
 
-	args.Replace("echo", "", pullRequestURL)
+	if flagBrowsePullRequestURL {
+		args.Before("echo", pullRequestURL)
+		launcher, err := utils.BrowserLauncher()
+		utils.Check(err)
+		args.Replace(launcher[0], "", launcher[1:]...)
+		args.AppendParams(pullRequestURL)
+	} else {
+		args.Replace("echo", "", pullRequestURL)
+	}
+
 	if flagPullRequestIssue != "" {
 		args.After("echo", "Warning: Issue to pull request conversion is deprecated and might not work in the future.")
 	}

--- a/features/pull_request.feature
+++ b/features/pull_request.feature
@@ -443,6 +443,19 @@ Feature: hub pull-request
     When I successfully run `hub pull-request -m hereyougo`
     Then the output should contain exactly "the://url\n"
 
+  Scenario: Open pull request in web browser
+    Given the "origin" remote has url "git://github.com/github/coral.git"
+    And the "doge" remote has url "git://github.com/mislav/coral.git"
+    And I am on the "feature" branch pushed to "doge/feature"
+    Given the GitHub API server:
+      """
+      post('/repos/github/coral/pulls') {
+        json :html_url => "the://url"
+      }
+      """
+    When I successfully run `hub pull-request -o -m hereyougo`
+    Then "open the://url" should be run
+
   @wip
   Scenario: Create pull request to "upstream" remote
     Given the "upstream" remote has url "git://github.com/github/coral.git"


### PR DESCRIPTION
Open pull-request url when `-o` or `-browse` option was passed. This is a
porting patch from github/hub's `pull-request` command.

FYI:
https://github.com/github/hub/blob/master/lib/hub/commands.rb#L167-L168
