### PR TITLE
Support push.default simple

### DIFF
--- a/commands/browse.go
+++ b/commands/browse.go
@@ -69,8 +69,7 @@ func browse(command *Command, args *Args) {
 		project = github.NewProject("", flagBrowseProject, "")
 	} else {
 		// gh browse
-		branch, project, err = localRepo.RemoteBranchAndProject("")
-		utils.Check(err)
+		branch, project, _ = localRepo.RemoteBranchAndProject("")
 	}
 
 	if project == nil {

--- a/github/localrepo.go
+++ b/github/localrepo.go
@@ -108,7 +108,7 @@ func (r *GitHubRepo) RemoteBranchAndProject(owner string) (branch *Branch, proje
 	}
 
 	pushDefault, _ := git.Config("push.default")
-	if pushDefault == "upstream" || pushDefault == "tracking" {
+	if pushDefault == "upstream" || pushDefault == "tracking" || pushDefault == "simple" {
 		branch, err = branch.Upstream()
 		if err != nil {
 			return


### PR DESCRIPTION
Git 2.0 set default push.default to simple. This commit enables gh to support
simple push strategy.

If there is no upstream branch, open master's branch.
