### PR TITLE
Stop converting ; to / in branch names

### DIFF
--- a/commands/compare.go
+++ b/commands/compare.go
@@ -3,7 +3,6 @@ package commands
 import (
 	"fmt"
 	"regexp"
-	"strings"
 
 	"github.com/jingweno/gh/github"
 	"github.com/jingweno/gh/utils"
@@ -73,7 +72,6 @@ func compare(command *Command, args *Args) {
 		}
 	}
 
-	r = strings.Replace(r, "/", ";", -1)
 	subpage := utils.ConcatPaths("compare", r)
 	url := project.WebURL("", "", subpage)
 	launcher, err := utils.BrowserLauncher()

--- a/features/compare.feature
+++ b/features/compare.feature
@@ -11,7 +11,7 @@ Feature: hub compare
    Scenario: Compare complex branch
     When I successfully run `hub compare feature/foo`
     Then there should be no output
-    And "open https://github.com/mislav/dotfiles/compare/feature;foo" should be run
+    And "open https://github.com/mislav/dotfiles/compare/feature/foo" should be run
 
   Scenario: No args, no upstream
     When I run `hub compare`


### PR DESCRIPTION
See corresponding fix in the hub client: https://github.com/github/hub/commit/27ebedd801d38ad974bb74084dba6707fb36efdb
